### PR TITLE
Update `as.data.frame` to handle Backblaze S3

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -92,22 +92,28 @@ get_objectkey.s3_object <- function(x, ...) {
 #' @export
 as.data.frame.s3_bucket <- function(x, row.names = NULL, optional = FALSE, ...) {
     if (length(x)) {
-        out <- lapply(x, function(z) {
-            c(Key = z[["Key"]],
-              LastModified = z[["LastModified"]],
-              ETag = z[["ETag"]],
-              Size = z[["Size"]],
-              Owner_ID =
-                ifelse(is.null(z[["Owner"]]), NA, z[["Owner"]][["ID"]]),
-              Owner_DisplayName =
-                ifelse(is.null(z[["Owner"]]), NA, z[["Owner"]][["DisplayName"]]),
-              StorageClass = z[["StorageClass"]],
-              Bucket = z[["Bucket"]])
+        x <- lapply(x, function(z) {
+        lst = c(Key = z[["Key"]],
+                LastModified = z[["LastModified"]],
+                ETag = z[["ETag"]],
+                Size = z[["Size"]],
+                Owner_ID = z[["Owner"]][["ID"]]),
+                Owner_DisplayName = z[["Owner"]][["DisplayName"]]),
+                StorageClass = z[["StorageClass"]],
+                Bucket = z[["Bucket"]])
+         
+        # any null values will be dropped, so add back in
+        # only seems to be a problem for the "Owner" properties, so assuming for
+        # now that the others are correct.
+        if(is.null(lst[["Owner_DisplayName"]])) lst[["Owner_DisplayName"]] = NA
+        if(is.null(lst[["Owner_ID"]])) lst[["Owner_ID"]] = NA
+        return(lst)  
+            
         })
         op <- options(stringsAsFactors = FALSE)
         on.exit(options(op))
-        out <- do.call("rbind.data.frame", unname(out))
-        names(out) <- c("Key", "LastModified", "ETag", "Size", "Owner_ID", "Owner_DisplayName", "StorageClass", "Bucket")
+        out <- do.call("rbind.data.frame", unname(x))
+        names(out) <- names(x$Contents)
         structure(out, row.names = if(!is.null(row.names)) row.names else seq_len(nrow(out)),
                        Marker = attributes(x)[["Marker"]],
                        IsTruncated = attributes(x)[["IsTruncated"]],


### PR DESCRIPTION
Backblaze S3 will return bucket lists without Owner:DisplayName. This causes `as.data.frame.s3_bucket` to fail when parsing the contents for `get_bucket_df`. This PR corrects that issue by ensuring that NULL values are changed to NA in the relevant cases.

Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.s3/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.s3/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.s3/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [ ] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.s3/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

